### PR TITLE
feat: add gradio tutorial interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,21 @@ main.py             # 多合一演示脚本
 
 ## 快速体验
 
-### 1. 聚类演示
-```bash
-python main.py cluster
-```
-脚本会生成一些示例点并使用模糊 C 均值进行聚类。
+启动一个包含教程的可视化网页界面：
 
-### 2. 图像特征点检测
 ```bash
-python main.py landmark path/to/image.jpg
+python main.py
 ```
-默认使用 dlib 作为检测器，可通过 `--method` 参数选择 `face_alignment`、`baidu` 或 `manual`。
 
-### 3. UV Map 生成
-```bash
-python main.py uvmap
-```
-随机生成一个网格并计算其 UV 映射，适合理解配准相关流程。
+浏览器中将打开多个标签页，覆盖以下功能：
+
+- **Fuzzy C-means**：二维数据的模糊聚类演示；
+- **Density Peaks**：基于密度峰值的簇中心选择；
+- **特征点检测**：上传人脸图片查看 2D 关键点；
+- **UV 映射**：随机顶点生成并展示对应的 UV 坐标；
+- **Delaunay**：对 UV 点集进行 Delaunay 三角剖分。
+
+每个页面都包含算法简介与交互式示例，便于理解与调试。
 
 ## 模块简介
 

--- a/main.py
+++ b/main.py
@@ -1,75 +1,141 @@
-"""Multi-tool demonstration script for the face_utils package.
+"""Gradio-based tutorial interface for the face_utils package."""
 
-This tutorial-style script exposes several small demos so beginners can
-quickly try out clustering, landmark detection and UV map generation.
-"""
-import argparse
 import numpy as np
+import matplotlib.pyplot as plt
 
-def demo_cluster(_: argparse.Namespace) -> None:
-    """Run a tiny Fuzzy C-means clustering example."""
-    from face_utils.ml import FCM
+import gradio as gr
+import cv2
 
-    data = np.array([[0,0], [0,1], [1,0], [9,9], [9,8], [8,9]], dtype=float)
+from face_utils.ml import FCM, density_showing
+from face_utils.reconstruction import landmark
+from face_utils.registration import uvmap_processing, delaunay_processing
+
+
+def demo_cluster() -> plt.Figure:
+    """Run a tiny Fuzzy C-means clustering example and return a plot."""
+    data = np.array([[0, 0], [0, 1], [1, 0], [9, 9], [9, 8], [8, 9]], dtype=float)
     weight = np.ones(data.shape[1])
     model = FCM(n_clusters=2, random_state=0)
     model.fit(data, X_Weight=weight)
     labels = model.predict(data, X_Weight=weight)
-    print("Cluster centers:\n", model._centers)
-    print("Labels:", labels)
 
-def demo_landmark(args: argparse.Namespace) -> None:
+    fig, ax = plt.subplots()
+    ax.scatter(data[:, 0], data[:, 1], c=labels, cmap="viridis")
+    ax.scatter(model._centers[:, 0], model._centers[:, 1], marker="x", color="red", s=100)
+    ax.set_title("Fuzzy C-means Clustering")
+    return fig
+
+
+def demo_density() -> plt.Figure:
+    """Visualize the decision graph for density peaks clustering."""
+    data = np.random.rand(30, 2)
+    rho, delta = density_showing(data, flag=False)
+    fig, ax = plt.subplots()
+    ax.scatter(rho, delta, c="black")
+    ax.set_xlabel("ρ (density)")
+    ax.set_ylabel("δ (distance to higher density)")
+    ax.set_title("Density Peaks Decision Graph")
+    return fig
+
+
+def demo_landmark(img: np.ndarray, method: str):
     """Detect facial landmarks on an image."""
-    try:
-        import cv2
-        from face_utils.reconstruction import landmark
-    except Exception as exc:
-        print("Landmark demo requires OpenCV and dlib:", exc)
-        return
-
-    img = cv2.imread(args.image)
     if img is None:
-        print(f"Cannot read image: {args.image}")
-        return
-    pts = landmark.landmark2d_detect(img, method=args.method, flag_show=False)
-    print(f"Detected {len(pts)} landmark points")
-
-def demo_uvmap(_: argparse.Namespace) -> None:
-    """Generate a UV map for a synthetic mesh."""
+        return None, "请上传图片"
     try:
-        from face_utils.registration import uvmap_processing
-    except Exception as exc:
-        print("UV map demo requires additional visualization libraries:", exc)
-        return
+        pts = landmark.landmark2d_detect(img, method=method, flag_show=False)
+        img_bgr = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+        for x, y in pts:
+            cv2.circle(img_bgr, (int(x), int(y)), 2, (0, 255, 0), -1)
+        out = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
+        return out, f"检测到 {len(pts)} 个特征点"
+    except Exception as exc:  # pragma: no cover - interactive demo
+        return None, f"检测失败: {exc}"
 
-    vertices = np.random.rand(100, 3)
-    uvmap = uvmap_processing.Vertices2Mapuv(vertices, flag_show=False, flag_select=False)
-    print("Generated UV map with shape", uvmap.shape)
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Face Utils tutorial demo")
-    sub = parser.add_subparsers(dest="command")
+def demo_uvmap() -> plt.Figure:
+    """Generate a UV map for a synthetic mesh and return a plot."""
+    try:
+        vertices = np.random.rand(100, 3)
+        info = uvmap_processing.Vertices2Mapuv(vertices, flag_show=False, flag_select=False)
+        uvmap = info.uvmap
+        fig, ax = plt.subplots()
+        ax.scatter(uvmap[:, 0], uvmap[:, 1], s=5)
+        ax.set_title("UV Map")
+        return fig
+    except Exception as exc:  # pragma: no cover - interactive demo
+        fig, ax = plt.subplots()
+        ax.text(0.5, 0.5, str(exc), ha="center", va="center")
+        ax.axis("off")
+        return fig
 
-    p_cluster = sub.add_parser("cluster", help="Run Fuzzy C-means clustering demo")
-    p_cluster.set_defaults(func=demo_cluster)
 
-    p_landmark = sub.add_parser("landmark", help="Detect landmarks on an image")
-    p_landmark.add_argument("image", help="Path to an input image")
-    p_landmark.add_argument("--method", default="dlib", choices=["dlib", "face_alignment", "baidu", "manual"], help="Detection backend")
-    p_landmark.set_defaults(func=demo_landmark)
+def demo_delaunay() -> plt.Figure:
+    """Triangulate UV points using Delaunay and show the mesh."""
+    uv = np.random.rand(30, 2)
+    try:
+        triangles = delaunay_processing.mapuv_Delaunay(uv)
+        fig, ax = plt.subplots()
+        ax.triplot(uv[:, 0], uv[:, 1], triangles, color="gray")
+        ax.scatter(uv[:, 0], uv[:, 1], color="red", s=10)
+        ax.set_title("Delaunay Triangulation")
+        return fig
+    except Exception as exc:  # pragma: no cover - interactive demo
+        fig, ax = plt.subplots()
+        ax.text(0.5, 0.5, str(exc), ha="center", va="center")
+        ax.axis("off")
+        return fig
 
-    p_uvmap = sub.add_parser("uvmap", help="Generate a UV map for a random mesh")
-    p_uvmap.set_defaults(func=demo_uvmap)
 
-    return parser
+def build_demo() -> gr.Blocks:
+    """Build the Gradio Blocks interface."""
+    with gr.Blocks() as demo:
+        gr.Markdown("# Face Utils Web Demo\n交互式教程覆盖 `face_utils` 中的主要算法。")
+        with gr.Tab("概览"):
+            gr.Markdown(
+                """
+                ## 模块介绍
+                - **ML**: 聚类算法，包括 Fuzzy C-means 与 Density Peaks。
+                - **Reconstruction**: 面部特征点检测、3D 重建等工具。
+                - **Registration**: UV 映射、Delaunay 三角剖分等配准相关方法。
+                选择其他标签查看具体示例。
+                """
+            )
+        with gr.Tab("Fuzzy C-means"):
+            gr.Markdown("使用 Fuzzy C-means 对二维点集进行模糊聚类。")
+            btn = gr.Button("运行示例")
+            plot = gr.Plot()
+            btn.click(demo_cluster, outputs=plot)
+        with gr.Tab("Density Peaks"):
+            gr.Markdown("展示密度峰值聚类的决策图，用于确定簇心。")
+            btn_dp = gr.Button("运行示例")
+            plot_dp = gr.Plot()
+            btn_dp.click(demo_density, outputs=plot_dp)
+        with gr.Tab("特征点检测"):
+            gr.Markdown("上传人脸图像并选择检测器，查看二维特征点位置。")
+            img_in = gr.Image(type="numpy", label="输入图像")
+            method = gr.Radio(["dlib", "face_alignment", "baidu", "manual"], value="dlib", label="检测器")
+            btn2 = gr.Button("开始检测")
+            img_out = gr.Image(label="结果")
+            info = gr.Textbox(label="信息")
+            btn2.click(demo_landmark, inputs=[img_in, method], outputs=[img_out, info])
+        with gr.Tab("UV 映射"):
+            gr.Markdown("随机生成顶点并计算对应的 UV 坐标。")
+            btn3 = gr.Button("生成示例")
+            plot_uv = gr.Plot()
+            btn3.click(demo_uvmap, outputs=plot_uv)
+        with gr.Tab("Delaunay"):
+            gr.Markdown("对 UV 点集进行 Delaunay 三角剖分。")
+            btn4 = gr.Button("运行示例")
+            plot_tri = gr.Plot()
+            btn4.click(demo_delaunay, outputs=plot_tri)
+    return demo
+
 
 def main() -> None:
-    parser = build_parser()
-    args = parser.parse_args()
-    if hasattr(args, "func"):
-        args.func(args)
-    else:
-        parser.print_help()
+    demo = build_demo()
+    demo.launch()
+
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,11 @@ version = "0.1.0"
 description = "Utilities for 3D face clustering, reconstruction, and registration"
 authors = [{name = "Robbie"}]
 requires-python = ">=3.8"
+dependencies = [
+    "numpy",
+    "matplotlib",
+    "opencv-python",
+    "gradio",
+    "scipy",
+    "scikit-learn"
+]


### PR DESCRIPTION
## Summary
- extend Gradio web app with density peaks clustering and Delaunay UV triangulation demos alongside existing clustering, landmark, and UV map examples
- document all interactive tabs and their purposes in README
- add scipy and scikit-learn to project dependencies for new features

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy gradio scipy scikit-learn -q` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68916675afc8832eb1ef3ad4ab9fd32b