### PR TITLE
Standardize author timestamps

### DIFF
--- a/face_utils/ml/clustering.py
+++ b/face_utils/ml/clustering.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Wed Sep 30 15:53:58 2025
+Created on 2025-09-30 15:53:58
 
 @author: Robbie
 """

--- a/face_utils/reconstruction/fitting.py
+++ b/face_utils/reconstruction/fitting.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Sat Jun  6 23:00:09 2025
+Created on 2025-06-06 23:00:09
 
 @author: Robbie
 """

--- a/face_utils/reconstruction/landmark.py
+++ b/face_utils/reconstruction/landmark.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Sat Apr  4 17:49:40 2025
+Created on 2025-04-04 17:49:40
 
 @author: Robbie
 """

--- a/face_utils/reconstruction/mesh.py
+++ b/face_utils/reconstruction/mesh.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Sun Jun  7 00:37:40 2025
+Created on 2025-06-07 00:37:40
 
 @author: Robbie
 """

--- a/face_utils/reconstruction/plyio.py
+++ b/face_utils/reconstruction/plyio.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Fri Jun  5 18:49:29 2025
+Created on 2025-06-05 18:49:29
 
 @author: Robbie
 """

--- a/face_utils/reconstruction/render.py
+++ b/face_utils/reconstruction/render.py
@@ -62,7 +62,7 @@ def pointTriangleDistance(TRI, P):
     #
     # Author: Gwolyn Fischer
     # Release: 1.0
-    # Release date: 09/02/02
+    # Release date: 2002-09-02
     # Release: 1.1 Fixed Bug because of normalization
     # Release: 1.2 Fixed Bug because of typo in region 5 20101013
     # Release: 1.3 Fixed Bug because of typo in region 2 20101014

--- a/face_utils/reconstruction/transform.py
+++ b/face_utils/reconstruction/transform.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Sat Jun  6 23:05:34 2025
+Created on 2025-06-06 23:05:34
 
 @author: Robbie
 """

--- a/face_utils/reconstruction/visualize.py
+++ b/face_utils/reconstruction/visualize.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Sat Apr  4 17:53:40 2025
+Created on 2025-04-04 17:53:40
 
 @author: Robbie
 """

--- a/face_utils/registration/delaunay_processing.py
+++ b/face_utils/registration/delaunay_processing.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Wed Oct 14 12:28:57 2025
+Created on 2025-10-14 12:28:57
 
 @author: Robbie
 """

--- a/face_utils/registration/face_corespond.py
+++ b/face_utils/registration/face_corespond.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Tue Mar 24 18:50:58 2025
+Created on 2025-03-24 18:50:58
 
 @author: Robbie
 """

--- a/face_utils/registration/face_registration/Face_Registration_cypcd_obj.py
+++ b/face_utils/registration/face_registration/Face_Registration_cypcd_obj.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Created on Fri Nov  6 21:57:36 2025
+Created on 2025-11-06 21:57:36
 
 @author: Robbie
 """

--- a/face_utils/registration/face_registration/Face_Registration_nricp_WRL_automaland.py
+++ b/face_utils/registration/face_registration/Face_Registration_nricp_WRL_automaland.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Tue Aug  4 20:33:49 2025
+Created on 2025-08-04 20:33:49
 
 @author: Robbie
 """

--- a/face_utils/registration/face_registration/Face_Registration_nricp_WRL_manualland.py
+++ b/face_utils/registration/face_registration/Face_Registration_nricp_WRL_manualland.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Tue Aug  4 20:33:49 2025
+Created on 2025-08-04 20:33:49
 
 @author: Robbie
 """

--- a/face_utils/registration/face_registration/Face_Registration_nricp_obj.py
+++ b/face_utils/registration/face_registration/Face_Registration_nricp_obj.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Created on Fri Nov  6 21:57:36 2025
+Created on 2025-11-06 21:57:36
 
 @author: Robbie
 """

--- a/face_utils/registration/face_registration/Face_Registration_nricp_ply_Adult.py
+++ b/face_utils/registration/face_registration/Face_Registration_nricp_ply_Adult.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Sat Apr  4 17:48:22 2025
+Created on 2025-04-04 17:48:22
 
 @author: Robbie
 """

--- a/face_utils/registration/face_registration/Face_Registration_nricp_ply_Adult_iges.py
+++ b/face_utils/registration/face_registration/Face_Registration_nricp_ply_Adult_iges.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Tue Aug  4 20:33:49 2025
+Created on 2025-08-04 20:33:49
 
 @author: Robbie
 """

--- a/face_utils/registration/face_registration/Face_Registration_nricp_ply_Baby.py
+++ b/face_utils/registration/face_registration/Face_Registration_nricp_ply_Baby.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Sat Apr  4 17:48:22 2025
+Created on 2025-04-04 17:48:22
 
 @author: Robbie
 """

--- a/face_utils/registration/face_registration/Face_Registration_nricp_ply_Children.py
+++ b/face_utils/registration/face_registration/Face_Registration_nricp_ply_Children.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Sat Apr  4 17:48:22 2025
+Created on 2025-04-04 17:48:22
 
 @author: Robbie
 """

--- a/face_utils/registration/model_transform.py
+++ b/face_utils/registration/model_transform.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Tue Oct 13 20:58:53 2025
+Created on 2025-10-13 20:58:53
 
 @author: Robbie
 """

--- a/face_utils/registration/nicp.py
+++ b/face_utils/registration/nicp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Created on Wed May 19 21:49:20 2025
+Created on 2025-05-19 21:49:20
 
 @author: Robbie
 """

--- a/face_utils/registration/uvmap_processing.py
+++ b/face_utils/registration/uvmap_processing.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Created on Tue Oct 13 20:03:45 2025
+Created on 2025-10-13 20:03:45
 
 @author: Robbie
 """


### PR DESCRIPTION
## Summary
- Replace non-standard `Created on` dates with ISO 8601 timestamps across author headers
- Normalize legacy release date format in rendering utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689187e6e81c832e87a5f0e5672bf057