### PR TITLE
Fix pydantic const usage and escape warning

### DIFF
--- a/face_utils/ml/clustering.py
+++ b/face_utils/ml/clustering.py
@@ -76,7 +76,7 @@ def density_showing(X,percent = 10.,dc=None,flag=False):
     tt=plot_histo(rho)
     plt.title(r"$\rho$ histogram",loc= 'left')
     
-    '''========================================================================================
+    r'''========================================================================================
     1. Determine maximum distance
     2. Sort \rho to find points of highest density
     3. Find nearest neighbors

--- a/face_utils/ml/fcmeans.py
+++ b/face_utils/ml/fcmeans.py
@@ -42,7 +42,7 @@ class FCM(BaseModel):
     m: float = Field(2.0, ge=1.0)
     error: float = Field(1e-5, ge=1e-9)
     random_state: Optional[int] = None
-    trained: bool = Field(False, const=True)
+    trained: bool = Field(False)
 
     #@validate_arguments(config=dict(arbitrary_types_allowed=True))
     def fit(self, X: NDArray, X_Weight: NDArray) -> None:


### PR DESCRIPTION
## Summary
- use a raw string to suppress escape warnings in density peak clustering docs
- remove deprecated `const=True` from FCM model for pydantic v2 compatibility

## Testing
- `python -Wall -m py_compile face_utils/ml/clustering.py`
- `python -Wall -m py_compile face_utils/ml/fcmeans.py`
- `pytest -q`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6891e1662bcc832e93c2701d574f7be2